### PR TITLE
📄 Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 botamochi0x12 and hakkibluoyd
+Copyright (c) 2021 botamochi0x12 and  muratcankilic96
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub does not recognize the LICENSE file as MIT License.